### PR TITLE
Field fixes, changes and tuning - Arrowheads - Manual Auto Heading&Depth

### DIFF
--- a/RovyMcRovFace.pro
+++ b/RovyMcRovFace.pro
@@ -93,7 +93,8 @@ HEADERS += \
     converter.h \
     position.h \
     fontsize.h \
-    biaswidget.h
+    biaswidget.h \
+    constantvalues.h
 
 FORMS += \
     secondarywindow.ui \

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -144,14 +144,12 @@ void BiasWidget::drawBackgroundArrows(QPainter *painter) {
 /// Draws all the real bias arrows
 /// @param * painter The QPainter object created in paintEvent
 void BiasWidget::drawBiasArrows(QPainter *painter) {
-
-    qDebug() << "drawBiasArrows: " << biasArrowLines->north.length();
-
     // we set new pens on every axis because they should have different colors
     painter->setPen(*biasArrowPenNorth);
-
+    // We need to extract the brush because somehow it is not avaible to extract from painter for some reason
     QBrush brush = biasArrowPenNorth->brush();
-    // check if we should draw the lines
+
+    // We must only draw the lines if their length is above zero. If we try to draw them with 0 length they will create a dot instead of nothing
     if (biasArrowLines->north.length() > 0) {
         painter->drawLine(biasArrowLines->north);
         drawArrowHead(painter, biasArrowLines->north, brush);
@@ -160,6 +158,7 @@ void BiasWidget::drawBiasArrows(QPainter *painter) {
         painter->drawLine(biasArrowLines->south);
         drawArrowHead(painter, biasArrowLines->south, brush);
     }
+
     painter->setPen(*biasArrowPenEast);
     brush = biasArrowPenEast->brush();
     if (biasArrowLines->west.length() > 0) {
@@ -262,10 +261,10 @@ void BiasWidget::drawBiasArrowLetters(QPainter *painter) {
     w_p.setY( w_p.y() + spacing * 0.8 );
 
     u_p.setX( u_p.x() - spacing * 0.35 );
-    u_p.setY( u_p.y() - spacing * 0.4 );
+    u_p.setY( u_p.y() - spacing * 0.8 );
 
     d_p.setX( d_p.x() - spacing * 0.35 );
-    d_p.setY( d_p.y() + spacing * 1.4 );
+    d_p.setY( d_p.y() + spacing * 1.6 );
 
     // set the font size
     QFont font = painter->font();

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -2,6 +2,7 @@
 #include <QLineF>
 #include <QDebug>
 #include "fontsize.h" // using only the linearTransform function
+#include <QPainterPath>
 
 BiasWidget::BiasWidget(QWidget *parent, int _frameWidth, int _frameHeight) : QWidget(parent)
 {
@@ -131,6 +132,13 @@ void BiasWidget::drawBackgroundArrows(QPainter *painter) {
     painter->drawLine(backgroundArrowLines->down);
     painter->drawLine(backgroundArrowLines->west);
     painter->drawLine(backgroundArrowLines->north);
+
+    drawArrowHead(painter, backgroundArrowLines->up);
+    drawArrowHead(painter, backgroundArrowLines->east);
+    drawArrowHead(painter, backgroundArrowLines->south);
+    drawArrowHead(painter, backgroundArrowLines->down);
+    drawArrowHead(painter, backgroundArrowLines->west);
+    drawArrowHead(painter, backgroundArrowLines->north);
 }
 
 /// Draws all the real bias arrows
@@ -157,6 +165,53 @@ void BiasWidget::drawBiasArrows(QPainter *painter) {
         painter->drawLine(biasArrowLines->up);
     if (biasArrowLines->down.length() > 0)
         painter->drawLine(biasArrowLines->down);
+}
+
+
+/// @brief Draws an arrowhead on the end of the given line
+/// @param painter is the painter given in paintEvent
+/// @param line is the line to draw an arrow on top of
+void BiasWidget::drawArrowHead(QPainter *painter, QLineF line) {
+    /*
+     * 1. get the three points of the triangle polygon with correct position and angle
+     * 2. draw a the polygon path
+     * 3. draw and fill the path
+     */
+
+    // make a copy of the line and invert it so that the starting point is now at the end point
+    QLineF *bottomLine = new QLineF(line.p2(), line.p1());
+
+    // set the size of the arrow
+    qreal arrowSize = fontSize / 2;
+
+    // extend the original line to get the top arrow point
+    line.setLength(line.length() + arrowSize);
+    QPointF newP3 = line.p2();
+    // shorten the length
+    bottomLine->setLength(arrowSize);
+
+    // rotate the line to be perpendicular
+    bottomLine->setAngle(bottomLine->angle() - 90);
+
+    // record the new p1 point
+    QPointF newP1 = bottomLine->p2();
+
+    //rotate it 180 degrees to mirror it
+    bottomLine->setAngle(bottomLine->angle() + 180);
+
+    // record the new p2 point
+    QPointF newP2 = bottomLine->p2();
+
+    // create a path for the triangle
+    QPainterPath path;
+
+    path.moveTo(newP1);
+    path.lineTo(newP2);
+    path.lineTo(newP3);
+    path.lineTo(newP1);
+
+    // finally paint the triangle
+    painter->fillPath(path, backgroundArrowPen->brush());
 }
 
 void BiasWidget::drawBiasArrowLetters(QPainter *painter) {

--- a/biaswidget.cpp
+++ b/biaswidget.cpp
@@ -133,12 +133,12 @@ void BiasWidget::drawBackgroundArrows(QPainter *painter) {
     painter->drawLine(backgroundArrowLines->west);
     painter->drawLine(backgroundArrowLines->north);
 
-    drawArrowHead(painter, backgroundArrowLines->up);
-    drawArrowHead(painter, backgroundArrowLines->east);
-    drawArrowHead(painter, backgroundArrowLines->south);
-    drawArrowHead(painter, backgroundArrowLines->down);
-    drawArrowHead(painter, backgroundArrowLines->west);
-    drawArrowHead(painter, backgroundArrowLines->north);
+    drawArrowHead(painter, backgroundArrowLines->up, backgroundArrowPen->brush());
+    drawArrowHead(painter, backgroundArrowLines->east, backgroundArrowPen->brush());
+    drawArrowHead(painter, backgroundArrowLines->south, backgroundArrowPen->brush());
+    drawArrowHead(painter, backgroundArrowLines->down, backgroundArrowPen->brush());
+    drawArrowHead(painter, backgroundArrowLines->west, backgroundArrowPen->brush());
+    drawArrowHead(painter, backgroundArrowLines->north, backgroundArrowPen->brush());
 }
 
 /// Draws all the real bias arrows
@@ -149,29 +149,46 @@ void BiasWidget::drawBiasArrows(QPainter *painter) {
 
     // we set new pens on every axis because they should have different colors
     painter->setPen(*biasArrowPenNorth);
-    if (biasArrowLines->north.length() > 0)
-        painter->drawLine(biasArrowLines->north);
-    if (biasArrowLines->south.length() > 0)
-        painter->drawLine(biasArrowLines->south);
 
+    QBrush brush = biasArrowPenNorth->brush();
+    // check if we should draw the lines
+    if (biasArrowLines->north.length() > 0) {
+        painter->drawLine(biasArrowLines->north);
+        drawArrowHead(painter, biasArrowLines->north, brush);
+    }
+    if (biasArrowLines->south.length() > 0) {
+        painter->drawLine(biasArrowLines->south);
+        drawArrowHead(painter, biasArrowLines->south, brush);
+    }
     painter->setPen(*biasArrowPenEast);
-    if (biasArrowLines->west.length() > 0)
+    brush = biasArrowPenEast->brush();
+    if (biasArrowLines->west.length() > 0) {
         painter->drawLine(biasArrowLines->west);
-    if (biasArrowLines->east.length() > 0)
+        drawArrowHead(painter, biasArrowLines->west, brush);
+    }
+    if (biasArrowLines->east.length() > 0) {
         painter->drawLine(biasArrowLines->east);
+        drawArrowHead(painter, biasArrowLines->east, brush);
+    }
 
     painter->setPen(*biasArrowPenDown);
-    if (biasArrowLines->up.length() > 0)
+    brush = biasArrowPenDown->brush();
+    if (biasArrowLines->up.length() > 0) {
         painter->drawLine(biasArrowLines->up);
-    if (biasArrowLines->down.length() > 0)
+        drawArrowHead(painter, biasArrowLines->up, brush);
+    }
+    if (biasArrowLines->down.length() > 0) {
         painter->drawLine(biasArrowLines->down);
+        drawArrowHead(painter, biasArrowLines->down, brush);
+    }
 }
 
 
 /// @brief Draws an arrowhead on the end of the given line
 /// @param painter is the painter given in paintEvent
 /// @param line is the line to draw an arrow on top of
-void BiasWidget::drawArrowHead(QPainter *painter, QLineF line) {
+/// @param brush is the brush that will be used to draw the triangle
+void BiasWidget::drawArrowHead(QPainter *painter, QLineF line, QBrush brush) {
     /*
      * 1. get the three points of the triangle polygon with correct position and angle
      * 2. draw a the polygon path
@@ -211,7 +228,7 @@ void BiasWidget::drawArrowHead(QPainter *painter, QLineF line) {
     path.lineTo(newP1);
 
     // finally paint the triangle
-    painter->fillPath(path, backgroundArrowPen->brush());
+    painter->fillPath(path, brush);
 }
 
 void BiasWidget::drawBiasArrowLetters(QPainter *painter) {

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -68,6 +68,7 @@ private:
     void drawBackgroundArrows(QPainter *painter);
     void drawBiasArrows(QPainter *painter);
     void drawBiasArrowLetters(QPainter *painter);
+    void drawArrowHead(QPainter *painter, QLineF line);
 
 signals:
 

--- a/biaswidget.h
+++ b/biaswidget.h
@@ -68,7 +68,7 @@ private:
     void drawBackgroundArrows(QPainter *painter);
     void drawBiasArrows(QPainter *painter);
     void drawBiasArrowLetters(QPainter *painter);
-    void drawArrowHead(QPainter *painter, QLineF line);
+    void drawArrowHead(QPainter *painter, QLineF line, QBrush brush);
 
 signals:
 

--- a/constantvalues.h
+++ b/constantvalues.h
@@ -1,0 +1,24 @@
+#ifndef CONSTANTVALUES_H
+#define CONSTANTVALUES_H
+
+
+class constantValues {
+public:
+    //Related to tcprov
+    static constexpr double depthAdjustment = 0.01;
+    static constexpr double headingAdjustment = 0.05;
+    static constexpr double maxThrusterHorizontal = 400;
+    static constexpr double maxThrusterVertical = 200;
+    static constexpr double maxThrusterHeading = 10; //FIND RIGHT VALUE
+
+    //Related to gamepadserver
+    // Gamepad update period
+    static const int UPDATE_PERIOD_MS = 15;
+    static constexpr double deadzoneX = 0.15;
+    static constexpr double deadzoneY = 0.15;
+    static const int maxJoystickValue = 32767;
+    static const int maxTriggerValue = 255;
+
+};
+#endif // CONSTANTVALUES_H
+

--- a/constantvalues.h
+++ b/constantvalues.h
@@ -5,11 +5,11 @@
 class constantValues {
 public:
     //Related to tcprov
-    static constexpr double depthAdjustment = 0.01;
-    static constexpr double headingAdjustment = 0.05;
+    static constexpr double depthAdjustment = 0.005;
+    static constexpr double headingAdjustment = 0.00125;
     static constexpr double maxThrusterHorizontal = 400;
     static constexpr double maxThrusterVertical = 200;
-    static constexpr double maxThrusterHeading = 10; //FIND RIGHT VALUE
+    static constexpr double maxThrusterHeading = 80; //FIND RIGHT VALUE
 
     //Related to gamepadserver
     // Gamepad update period

--- a/gamepadserver.cpp
+++ b/gamepadserver.cpp
@@ -1,4 +1,5 @@
 #include "gamepadserver.h"
+#include "constantvalues.h"
 
 #include <Windows.h>
 #include <Xinput.h>
@@ -21,7 +22,7 @@ GamepadServer::GamepadServer()
 {
     QTimer * gameServerTimer = new QTimer(this);
     connect(gameServerTimer, SIGNAL(timeout()), this, SLOT(readState()));
-    gameServerTimer->start(UPDATE_PERIOD_MS);
+    gameServerTimer->start(constantValues::UPDATE_PERIOD_MS);
 }
 
 void GamepadServer::readState() {
@@ -81,21 +82,18 @@ namespace GamepadServerLocal {
     }
 
     void updateAnalogs(GamepadState & gps, const XINPUT_GAMEPAD & xStatePad) {
-        gps.m_lTrigger = (double) xStatePad.bLeftTrigger/GamepadServer::maxTriggerValue;
-        gps.m_rTrigger = (double) xStatePad.bRightTrigger/GamepadServer::maxTriggerValue;
-        gps.m_lThumb.xAxis = (double) xStatePad.sThumbLX/GamepadServer::maxJoystickValue;
-        gps.m_lThumb.yAxis = (double) xStatePad.sThumbLY/GamepadServer::maxJoystickValue;
-        gps.m_rThumb.xAxis = (double) xStatePad.sThumbRX/GamepadServer::maxJoystickValue;
-        gps.m_rThumb.yAxis = (double) xStatePad.sThumbRY/GamepadServer::maxJoystickValue;
-
-        double deadzoneX = 0.25;
-        double deadzoneY = 0.25;
+        gps.m_lTrigger = (double) xStatePad.bLeftTrigger/constantValues::maxTriggerValue;
+        gps.m_rTrigger = (double) xStatePad.bRightTrigger/constantValues::maxTriggerValue;
+        gps.m_lThumb.xAxis = (double) xStatePad.sThumbLX/constantValues::maxJoystickValue;
+        gps.m_lThumb.yAxis = (double) xStatePad.sThumbLY/constantValues::maxJoystickValue;
+        gps.m_rThumb.xAxis = (double) xStatePad.sThumbRX/constantValues::maxJoystickValue;
+        gps.m_rThumb.yAxis = (double) xStatePad.sThumbRY/constantValues::maxJoystickValue;
 
         // Factoring in deadzone
-        gps.m_lThumb.xAxis = (abs(gps.m_lThumb.xAxis) < deadzoneX ? 0 : gps.m_lThumb.xAxis);
-        gps.m_lThumb.yAxis = (abs(gps.m_lThumb.yAxis) < deadzoneY ? 0 : gps.m_lThumb.yAxis);
-        gps.m_rThumb.xAxis = (abs(gps.m_rThumb.xAxis) < deadzoneX ? 0 : gps.m_rThumb.xAxis);
-        gps.m_rThumb.yAxis = (abs(gps.m_rThumb.yAxis) < deadzoneY ? 0 : gps.m_rThumb.yAxis);
+        gps.m_lThumb.xAxis = (abs(gps.m_lThumb.xAxis) < constantValues::deadzoneX ? 0 : gps.m_lThumb.xAxis);
+        gps.m_lThumb.yAxis = (abs(gps.m_lThumb.yAxis) < constantValues::deadzoneY ? 0 : gps.m_lThumb.yAxis);
+        gps.m_rThumb.xAxis = (abs(gps.m_rThumb.xAxis) < constantValues::deadzoneX ? 0 : gps.m_rThumb.xAxis);
+        gps.m_rThumb.yAxis = (abs(gps.m_rThumb.yAxis) < constantValues::deadzoneY ? 0 : gps.m_rThumb.yAxis);
     }
 
 }

--- a/gamepadserver.h
+++ b/gamepadserver.h
@@ -17,13 +17,7 @@ public:
         return *s_instance;
     }
 
-    // Gamepad update period
-    const int UPDATE_PERIOD_MS = 15;
 
-    static constexpr double deadzoneX = 0.15;
-    static constexpr double deadzoneY = 0.15;
-    static const int maxJoystickValue = 32767;
-    static const int maxTriggerValue = 255;
 
 signals:
     void stateUpdate(const GamepadState & gps, const int & player);

--- a/main.cpp
+++ b/main.cpp
@@ -105,6 +105,8 @@ int main(int argc, char *argv[])
     // connect "set auto H & W" gui elements to tcp rov
     QObject::connect(&w2, qOverload<double>(&SecondaryWindow::updateAutoHeading), tcpRov, &TcpRov::setAutoHeading);
     QObject::connect(&w2, qOverload<double>(&SecondaryWindow::updateAutoDepth), tcpRov, &TcpRov::setAutoDepth);
+    QObject::connect(&w2, qOverload<double>(&SecondaryWindow::updateReferenceHeading), tcpRov, &TcpRov::setReferenceHeading);
+    QObject::connect(&w2, qOverload<double>(&SecondaryWindow::updateReferenceDepth), tcpRov, &TcpRov::setReferenceDepth);
 
     HeadingWidget * hw = w1.headingWidget;
     // conect rov values to headingWidget

--- a/main.cpp
+++ b/main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char *argv[])
     QRect screenGeometryMainWindow = qList[0]->geometry();
 
     if (qList.length() >= 2) {
+        /* Code that somehow did not work: the overlay in mainwindow do not show
         //Both windows are made fullscreen && w1 => primarydisplay && w2 => secondary display
         w1.setWindowFlags(Qt::FramelessWindowHint);
         w1.showFullScreen();
@@ -44,8 +45,23 @@ int main(int argc, char *argv[])
         // If we want the window to always stay on top we can use Qt::WindowStaysOnTopHint
         w2.setWindowFlags(Qt::FramelessWindowHint);
         w2.showFullScreen();
+        */
 
-        // Should we add the posibility of secondary window keeping track of own variables?
+        w1.setWindowFlags(Qt::FramelessWindowHint);
+        int width = qList[0]->geometry().width();
+        int height = qList[0]->geometry().height();
+
+        w1.windowWidth = width;
+        w1.windowHeight = height;
+        w1.resize(width, height);
+        w1.move(0,0);
+
+        w2.setWindowFlags(Qt::FramelessWindowHint);
+        width = qList[1]->geometry().width();
+        height = qList[1]->geometry().height();
+        w2.resize(width, height);
+        w2.move(qList[0]->geometry().width(), 0);
+
     } else {
         //There is only one screen - put the windows side by side on the same screen
         int height = screenGeometryMainWindow.height() / 2;

--- a/main.cpp
+++ b/main.cpp
@@ -88,18 +88,19 @@ int main(int argc, char *argv[])
 
     // connect "set auto H & W" gui elements to tcp rov
     QObject::connect(&w2, qOverload<double>(&SecondaryWindow::updateAutoHeading), tcpRov, &TcpRov::setAutoHeading);
+    QObject::connect(&w2, qOverload<double>(&SecondaryWindow::updateAutoDepth), tcpRov, &TcpRov::setAutoDepth);
 
     HeadingWidget * hw = w1.headingWidget;
     // conect rov values to headingWidget
     QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateYaw), hw, &HeadingWidget::updateYaw);
-    QObject::connect(&w1, qOverload<double>(&MainWindow::updateYawReference), hw, &HeadingWidget::updateYawReference);
+    QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateReferenceHeading), hw, &HeadingWidget::updateYawReference);
     QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateAutoHeading), hw, &HeadingWidget::updateAutoHeading);
 
 
     DepthWidget * dw = w1.depthWidget;
     QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateDepth), dw, &DepthWidget::updateDepth);
     QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateAutoDepth), dw, &DepthWidget::updateAutoDepth);
-    QObject::connect(&w1, qOverload<double>(&MainWindow::updateDepthReference), dw, &DepthWidget::updateDepthReference);
+    QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateReferenceDepth), dw, &DepthWidget::updateDepthReference);
 
     BiasWidget * bw = w1.biasWidget;
     QObject::connect(tcpRov, qOverload<double, double, double>(&TcpRov::updateBias), bw, &BiasWidget::updateBias);

--- a/main.cpp
+++ b/main.cpp
@@ -86,16 +86,19 @@ int main(int argc, char *argv[])
     // connect rov values with ui and tcpRov
     QObject::connect(tcpRov, SIGNAL(updateROVValues(double, double, double, double, double, double)), &w2, SLOT(updateROVValues(double, double, double, double, double, double)) );
 
+    // connect "set auto H & W" gui elements to tcp rov
+    QObject::connect(&w2, qOverload<double>(&SecondaryWindow::updateAutoHeading), tcpRov, &TcpRov::setAutoHeading);
+
     HeadingWidget * hw = w1.headingWidget;
     // conect rov values to headingWidget
     QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateYaw), hw, &HeadingWidget::updateYaw);
     QObject::connect(&w1, qOverload<double>(&MainWindow::updateYawReference), hw, &HeadingWidget::updateYawReference);
-    QObject::connect(&w1, qOverload<double>(&MainWindow::updateAutoHeading), hw, &HeadingWidget::updateAutoHeading);
+    QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateAutoHeading), hw, &HeadingWidget::updateAutoHeading);
 
 
     DepthWidget * dw = w1.depthWidget;
     QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateDepth), dw, &DepthWidget::updateDepth);
-    QObject::connect(&w1, qOverload<double>(&MainWindow::updateAutoDepth), dw, &DepthWidget::updateAutoDepth);
+    QObject::connect(tcpRov, qOverload<double>(&TcpRov::updateAutoDepth), dw, &DepthWidget::updateAutoDepth);
     QObject::connect(&w1, qOverload<double>(&MainWindow::updateDepthReference), dw, &DepthWidget::updateDepthReference);
 
     BiasWidget * bw = w1.biasWidget;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -89,6 +89,9 @@ void MainWindow::checkAndHandleFlag(bool button, bool& lastKeyState, double& fla
             } else {
                 flag = 0;
             }
+            tcpRov->autoHeadingWasUpdated();
+            tcpRov->autoDepthWasUpdated();
+
          } lastKeyState = 1;
     } else {
         lastKeyState = 0;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -30,12 +30,6 @@ public:
 
     void setupUI();
 
-signals:
-    void updateDepthReference(double _depth);
-    void updateYawReference(double _yaw);
-    void updateAutoHeading(double _autoHeading);
-    void updateAutoDepth(double _autoDepth);
-
 private slots:
     //void on_depth_slider_valueChanged(int value);
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -9,6 +9,7 @@
 #include "headingwidget.h"
 #include "depthwidget.h"
 #include "biaswidget.h"
+#include "constantvalues.h"
 
 class MainWindow : public QMainWindow
 {

--- a/secondarywindow.cpp
+++ b/secondarywindow.cpp
@@ -62,3 +62,35 @@ void SecondaryWindow::updateROVValues(double _north, double _east, double _down,
     ui->pitch->display(_pitch);
     ui->yaw->display(_yaw);
 }
+
+/// @brief when check button "autoHeadingCheck" in ui is toggled this function is called
+/// @param checked is true if checkbox was checked
+void SecondaryWindow::on_autoHeadingCheck_toggled(bool checked)
+{
+    if (checked)
+        emit updateAutoHeading(1);
+    else
+        emit updateAutoHeading(0);
+}
+
+/// @brief when check button "autoDepthCheck" in ui is toggled this function is called
+/// @param checked is true if checkbox was checked
+void SecondaryWindow::on_autoDepthCheck_toggled(bool checked)
+{
+    if (checked)
+        emit updateAutoDepth(1);
+    else
+        emit updateAutoDepth(0);
+}
+
+/// @brief when user has finnished entering a value (by clicking away or pressing enter) in "autoHeadingValue" this function is called.
+void SecondaryWindow::on_autoHeadingValue_editingFinished()
+{
+    emit updateReferenceHeading(ui->autoHeadingValue->value());
+}
+
+/// @brief when user has finnished entering a value (by clicking away or pressing enter) in "autoDepthValue" this function is called.
+void SecondaryWindow::on_autoDepthValue_editingFinished()
+{
+    emit updateReferenceDepth(ui->autoDepthValue->value());
+}

--- a/secondarywindow.cpp
+++ b/secondarywindow.cpp
@@ -36,9 +36,12 @@ void SecondaryWindow::on_openSimulator_clicked()
 
     // the commands are prepended by a "start" because "start" will spawn a new process so this program doesnt halt.
     // Runs the simulator:
-    system("start C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/runrtvisROV6DOF.bat && exit");
-    // Runs the python program that sends commands to the simulator. Program replaces a physical controller. This is required when not using a physical controller
-    //system("start python C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/tcp_rov_forces.py && exit");
+
+    // this is the latest version which do not include the fishfarm.
+    //system("start C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/runrtvisROV6DOF_autoDH_thrA.bat && exit");
+
+    // This is the latest version with fishfarm, warning this sim is pretty resource intensive
+    system("start C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/runrtvisROV6DOF_autoDH_thrA_fish.bat && exit");
 
     // emits signal so that we can connect to the ROV using tcp
     emit connectToROV();

--- a/secondarywindow.cpp
+++ b/secondarywindow.cpp
@@ -98,10 +98,10 @@ void SecondaryWindow::on_autoDepthValue_editingFinished()
     emit updateReferenceDepth(ui->autoDepthValue->value());
 }
 
+/// @brief connects to the real ROV trough serial port / sintef's backend
 void SecondaryWindow::on_rovSerial_clicked()
 {
     // connect to serial port
     system("start C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/runrtvisrunROV_ver1.bat && exit");
-
-
 }
+

--- a/secondarywindow.cpp
+++ b/secondarywindow.cpp
@@ -1,7 +1,7 @@
 #include "secondarywindow.h"
 #include "ui_secondarywindow.h"
 #include <QDebug>
-
+#include "converter.h"
 
 SecondaryWindow::SecondaryWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -89,13 +89,15 @@ void SecondaryWindow::on_autoDepthCheck_toggled(bool checked)
 /// @brief when user has finnished entering a value (by clicking away or pressing enter) in "autoHeadingValue" this function is called.
 void SecondaryWindow::on_autoHeadingValue_editingFinished()
 {
-    emit updateReferenceHeading(ui->autoHeadingValue->value());
+    double rad = Converter::degToRad(ui->autoHeadingValue->value());
+    emit updateReferenceHeading(rad);
 }
 
 /// @brief when user has finnished entering a value (by clicking away or pressing enter) in "autoDepthValue" this function is called.
 void SecondaryWindow::on_autoDepthValue_editingFinished()
 {
-    emit updateReferenceDepth(ui->autoDepthValue->value());
+    double rad = Converter::degToRad(ui->autoDepthValue->value());
+    emit updateReferenceDepth(rad);
 }
 
 /// @brief connects to the real ROV trough serial port / sintef's backend

--- a/secondarywindow.cpp
+++ b/secondarywindow.cpp
@@ -94,3 +94,11 @@ void SecondaryWindow::on_autoDepthValue_editingFinished()
 {
     emit updateReferenceDepth(ui->autoDepthValue->value());
 }
+
+void SecondaryWindow::on_rovSerial_clicked()
+{
+    // connect to serial port
+    system("start C:/_work/FhSim/sfhdev/FhSimPlayPen_vs14_amd64/bin/tcp/runrtvisrunROV_ver1.bat && exit");
+
+
+}

--- a/secondarywindow.h
+++ b/secondarywindow.h
@@ -45,6 +45,7 @@ public slots:
 
     void updateROVValues(double, double, double, double, double, double);
 
+
 private slots:
 
     void on_autoHeadingCheck_toggled(bool checked);

--- a/secondarywindow.h
+++ b/secondarywindow.h
@@ -55,6 +55,8 @@ private slots:
 
     void on_autoDepthValue_editingFinished();
 
+    void on_rovSerial_clicked();
+
 private:
     Ui::SecondaryWindow *ui;
 

--- a/secondarywindow.h
+++ b/secondarywindow.h
@@ -33,6 +33,10 @@ public:
 
 signals:
     void connectToROV();
+    void updateAutoHeading(double _active);
+    void updateAutoDepth(double _active);
+    void updateReferenceHeading(double _ref);
+    void updateReferenceDepth(double _ref);
 
 public slots:
     void on_openSimulator_clicked();
@@ -40,6 +44,16 @@ public slots:
     void on_connectROV_clicked();
 
     void updateROVValues(double, double, double, double, double, double);
+
+private slots:
+
+    void on_autoHeadingCheck_toggled(bool checked);
+
+    void on_autoDepthCheck_toggled(bool checked);
+
+    void on_autoHeadingValue_editingFinished();
+
+    void on_autoDepthValue_editingFinished();
 
 private:
     Ui::SecondaryWindow *ui;

--- a/secondarywindow.ui
+++ b/secondarywindow.ui
@@ -50,7 +50,7 @@
       <item row="0" column="0">
        <widget class="QTabWidget" name="tabWidget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>2</number>
         </property>
         <widget class="QWidget" name="tab">
          <property name="sizePolicy">
@@ -60,7 +60,7 @@
           </sizepolicy>
          </property>
          <attribute name="title">
-          <string>Tab 1</string>
+          <string>Map</string>
          </attribute>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
@@ -84,7 +84,7 @@
         </widget>
         <widget class="QWidget" name="tab_2">
          <attribute name="title">
-          <string>Tab 2</string>
+          <string>Values recived</string>
          </attribute>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
@@ -153,6 +153,175 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="tab_3">
+         <property name="maximumSize">
+          <size>
+           <width>564</width>
+           <height>289</height>
+          </size>
+         </property>
+         <attribute name="title">
+          <string>Set Auto Heading and Depth</string>
+         </attribute>
+         <widget class="QWidget" name="gridLayoutWidget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>561</width>
+            <height>281</height>
+           </rect>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="4" column="1">
+            <widget class="QLabel" name="label_8">
+             <property name="font">
+              <font>
+               <pointsize>12</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Auto Depth</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_7">
+             <property name="font">
+              <font>
+               <pointsize>12</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Auto Heading</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="6">
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="2">
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="4">
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="3" column="1">
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="1">
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="4" column="5">
+            <widget class="QDoubleSpinBox" name="autoDepthValue">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>359.899999999999977</double>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QCheckBox" name="autoHeadingCheck">
+             <property name="text">
+              <string>Activate</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="5">
+            <widget class="QDoubleSpinBox" name="autoHeadingValue">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>359.899999999999977</double>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <spacer name="horizontalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="4" column="3">
+            <widget class="QCheckBox" name="autoDepthCheck">
+             <property name="text">
+              <string>Activate</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
        </widget>
       </item>
       <item row="0" column="1">
@@ -179,9 +348,6 @@
          <layout class="QHBoxLayout" name="powerstat_col"/>
         </item>
        </layout>
-      </item>
-      <item row="1" column="1">
-       <layout class="QHBoxLayout" name="ctester_col"/>
       </item>
       <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
@@ -229,6 +395,9 @@
          <layout class="QHBoxLayout" name="horizontalLayout_8"/>
         </item>
        </layout>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="ctester_col"/>
       </item>
      </layout>
     </item>

--- a/secondarywindow.ui
+++ b/secondarywindow.ui
@@ -374,7 +374,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Start simulator, start tcp_rov_forces.py and start obs streaming</string>
+             <string>Start simulator</string>
             </property>
            </widget>
           </item>
@@ -385,14 +385,22 @@
           <item>
            <widget class="QPushButton" name="connectROV">
             <property name="text">
-             <string>Connect to ROV</string>
+             <string>Connect to TCP</string>
             </property>
            </widget>
           </item>
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_8"/>
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <item>
+           <widget class="QPushButton" name="rovSerial">
+            <property name="text">
+             <string>Start ROV serial port</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>

--- a/tcprov.cpp
+++ b/tcprov.cpp
@@ -305,13 +305,14 @@ void winsockConnect(SOCKET *_ConnectSocket, addrinfo *ptr) {
 /// @param _ref double reference heading [0, 2 * PI) radians
 void TcpRov::setReferenceHeading(double _ref) {
     referenceHeading = _ref;
+    nextData.yaw = _ref;
 }
 
 /// @brief sets the reference depth. only used when auto depth is set
 /// @param _ref double reference depth [0, 200] meters
 void TcpRov::setReferenceDepth(double _ref) {
-    qDebug() << "Seting reference depth to " << _ref;
     referenceDepth = _ref;
+    nextData.heave = _ref;
 }
 
 

--- a/tcprov.cpp
+++ b/tcprov.cpp
@@ -301,4 +301,17 @@ void winsockConnect(SOCKET *_ConnectSocket, addrinfo *ptr) {
     }
 }
 
+/// @brief sets the reference heading. only used when auto heading is set
+/// @param _ref double reference heading [0, 2 * PI) radians
+void TcpRov::setReferenceHeading(double _ref) {
+    referenceHeading = _ref;
+}
+
+/// @brief sets the reference depth. only used when auto depth is set
+/// @param _ref double reference depth [0, 200] meters
+void TcpRov::setReferenceDepth(double _ref) {
+    qDebug() << "Seting reference depth to " << _ref;
+    referenceDepth = _ref;
+}
+
 

--- a/tcprov.cpp
+++ b/tcprov.cpp
@@ -234,13 +234,13 @@ void TcpRov::setValues(double north, double east, double down, double roll, doub
 /// sets the auto heading flag to 0 or 1
 void TcpRov::setAutoHeading(double _autoHeading) {
     autoHeading = _autoHeading;
-    emit updateFlags(autoHeading, autoDepth);
+    emit updateAutoHeading(autoHeading);
 }
 
 /// sets the auto depth flag to 0 or 1
 void TcpRov::setAutoDepth(double _autoDepth) {
     autoDepth = _autoDepth;
-    emit updateFlags(autoHeading, autoDepth);
+    emit updateAutoDepth(autoDepth);
 }
 
 // this function resets all the nextData variables to zero. This is done such that we don't double send data.

--- a/tcprov.cpp
+++ b/tcprov.cpp
@@ -231,14 +231,16 @@ void TcpRov::setValues(double north, double east, double down, double roll, doub
     nextData.autoHeading = autoHeading;
 }
 
-void TcpRov::toggleAutoDepth() {
-    nextData.autoDepth = (nextData.autoDepth == 0 ? 1 : 0);
-    emit updateFlags(nextData.autoDepth, nextData.autoHeading);
+/// sets the auto heading flag to 0 or 1
+void TcpRov::setAutoHeading(double _autoHeading) {
+    autoHeading = _autoHeading;
+    emit updateFlags(autoHeading, autoDepth);
 }
 
-void TcpRov::toggleAutoHeading() {
-    nextData.autoHeading = (nextData.autoHeading == 0 ? 1 : 0);
-    emit updateFlags(nextData.autoDepth, nextData.autoHeading);
+/// sets the auto depth flag to 0 or 1
+void TcpRov::setAutoDepth(double _autoDepth) {
+    autoDepth = _autoDepth;
+    emit updateFlags(autoHeading, autoDepth);
 }
 
 // this function resets all the nextData variables to zero. This is done such that we don't double send data.

--- a/tcprov.cpp
+++ b/tcprov.cpp
@@ -250,6 +250,18 @@ void TcpRov::setAutoDepth(double _autoDepth) {
     emit updateAutoDepth(_autoDepth);
 }
 
+/// The same as the functions above but it does not recive or set a value. Should only be called if autoHeading is NOT set by functions above
+void TcpRov::autoHeadingWasUpdated() {
+    nextData.autoHeading = autoHeading;
+    emit updateAutoHeading(autoHeading);
+}
+
+/// The same as the functions above but it does not recive or set a value. Should only be called if autoDepth is NOT set by functions above
+void TcpRov::autoDepthWasUpdated() {
+    nextData.autoDepth = autoDepth;
+    emit updateAutoDepth(autoDepth);
+}
+
 // this function resets all the nextData variables to zero. This is done such that we don't double send data.
 void TcpRov::resetAllValues() {
     nextData.surge = 0;

--- a/tcprov.cpp
+++ b/tcprov.cpp
@@ -64,7 +64,12 @@ void TcpRov::tcpRead() {
     emit updateYaw(readData.yaw);
     emit updateDepth(readData.down);
     emit updateBias(biasSurge, biasSway, biasHeave);
-
+    if (nextData.autoHeading >= 1) {
+        emit updateReferenceHeading(nextData.yaw);
+    }
+    if (nextData.autoDepth >= 1) {
+        emit updateReferenceDepth(nextData.heave);
+    }
     // send next data
     tcpSend();
 }
@@ -220,27 +225,29 @@ void TcpRov::setValues(double north, double east, double down, double roll, doub
 }
 
 // [future] this function will set all variables
-void TcpRov::setValues(double north, double east, double down, double roll, double pitch, double yaw, double autoDepth, double autoHeading) {
-    nextData.surge = north;
-    nextData.sway = east;
-    nextData.heave = down;
-    nextData.roll = roll;
-    nextData.pitch = pitch;
-    nextData.yaw = yaw;
-    nextData.autoDepth = autoDepth;
-    nextData.autoHeading = autoHeading;
+void TcpRov::setValues(double _north, double _east, double _down, double _roll, double _pitch, double _yaw, double _autoDepth, double _autoHeading) {
+    nextData.surge = _north;
+    nextData.sway = _east;
+    nextData.heave = _down;
+    nextData.roll = _roll;
+    nextData.pitch = _pitch;
+    nextData.yaw = _yaw;
+    nextData.autoDepth = _autoDepth;
+    nextData.autoHeading = _autoHeading;
 }
 
 /// sets the auto heading flag to 0 or 1
 void TcpRov::setAutoHeading(double _autoHeading) {
     autoHeading = _autoHeading;
-    emit updateAutoHeading(autoHeading);
+    nextData.autoHeading = _autoHeading;
+    emit updateAutoHeading(_autoHeading);
 }
 
 /// sets the auto depth flag to 0 or 1
 void TcpRov::setAutoDepth(double _autoDepth) {
     autoDepth = _autoDepth;
-    emit updateAutoDepth(autoDepth);
+    nextData.autoDepth = _autoDepth;
+    emit updateAutoDepth(_autoDepth);
 }
 
 // this function resets all the nextData variables to zero. This is done such that we don't double send data.

--- a/tcprov.h
+++ b/tcprov.h
@@ -78,7 +78,8 @@ signals:
     void updateROVValues(double, double, double, double, double, double);
     void updateYaw(double);
     void updateDepth(double);
-    void updateFlags(double, double);
+    void updateAutoHeading(double _autoHeading);
+    void updateAutoDepth(double _autoDepth);
     void updateBias(double, double, double);
 
 public slots:

--- a/tcprov.h
+++ b/tcprov.h
@@ -92,8 +92,8 @@ public slots:
     void resetValuesButNotFlagValues();
     void startTcpReadTimer();
     void stopTcpReadTimer();
-    void toggleAutoDepth();
-    void toggleAutoHeading();
+    void setAutoHeading(double _autoHeading);
+    void setAutoDepth(double _autoDepth);
 
 };
 

--- a/tcprov.h
+++ b/tcprov.h
@@ -80,6 +80,8 @@ signals:
     void updateDepth(double);
     void updateAutoHeading(double _autoHeading);
     void updateAutoDepth(double _autoDepth);
+    void updateReferenceHeading(double _autoHeading);
+    void updateReferenceDepth(double _autoDepth);
     void updateBias(double, double, double);
 
 public slots:

--- a/tcprov.h
+++ b/tcprov.h
@@ -97,6 +97,8 @@ public slots:
     void stopTcpReadTimer();
     void setAutoHeading(double _autoHeading);
     void setAutoDepth(double _autoDepth);
+    void autoHeadingWasUpdated();
+    void autoDepthWasUpdated();
 
 };
 

--- a/tcprov.h
+++ b/tcprov.h
@@ -20,16 +20,11 @@ public:
     double timeStep = 0.1;					// Communication interval
     double recNum = 4;						// Number of messages (8-byte double precision numbers) to receive
     double senNum = 4;						// Number of messages (8-byte double precision numbers) to send
-    static constexpr double maxThrusterHorizontal = 400;
-    static constexpr double maxThrusterVertical = 200;
-    static constexpr double maxThrusterHeading = 10; //FIND RIGHT VALUE
 
     double autoDepth = 0;
     double autoHeading = 0;
     double referenceDepth = 0;
-    double depthAdjustment = 0.01;
     double referenceHeading = 0;
-    double headingAdjustment = 0.05;
 
     double biasSurge = 0;
     double biasSway = 0;

--- a/tcprov.h
+++ b/tcprov.h
@@ -88,8 +88,6 @@ public slots:
     void tcpConnect();
     void tcpRead();
     void tcpSend();
-    void setValues(double, double, double, double);
-    void setValues(double, double, double, double, double, double);
     void setValues(double, double, double, double, double, double, double, double);
     void resetAllValues();
     void resetValuesButNotFlagValues();
@@ -99,6 +97,9 @@ public slots:
     void setAutoDepth(double _autoDepth);
     void autoHeadingWasUpdated();
     void autoDepthWasUpdated();
+    void setReferenceHeading(double _ref);
+    void setReferenceDepth(double _ref);
+
 
 };
 


### PR DESCRIPTION
**The things introduced in this PR was requested after the project had ended, since we were in the field after the delivery date. Therefore this PR is technically not part of the course.** 

This pr will mostly contain all the fixes, changes and tunings we did in the field. Because of time issues, most of these commits do not have their own commit.

This pr will also introduce arrowheads and a manual auto heading and auto depth tab.

## Arrowheads
There are now arrowheads on top of all bias arrows. They are always drawn on the backgroundBiasArrows and will only draw on bias arrows if they are active. 
![image](https://user-images.githubusercontent.com/13204226/49009787-b7ad8180-f171-11e8-9da9-48c24d23cbaf.png)


## Manual Auto Heading and Auto Depth
We have added a new tab containing a way to manually active auto heading and auto depth and set a reference value for them

Since this feature was requested after the projects end this feature is not yet 100% stable. 

For example, when you activate auto heading it will automatically set the reference heading to 0. (which means the rov will rotate) until you either touch the controller or enter a new value. I think this is because we update the reference in the code relating to the controller.

But hey, it works :)))

![image](https://user-images.githubusercontent.com/13204226/49009714-88971000-f171-11e8-9b77-9cc73ae195f1.png)
